### PR TITLE
Tuning the performance ~20 times faster by caching InjectionMap instances

### DIFF
--- a/src/org/osflash/vanilla/Vanilla.as
+++ b/src/org/osflash/vanilla/Vanilla.as
@@ -46,7 +46,7 @@ package org.osflash.vanilla
 			    addReflectedRules(injectionMapCache[targetType], targetType, Type.forClass(targetType));
 			}
 			
-			const injectionMap = injectionMapCache[targetType];
+			const injectionMap:InjectionMap = injectionMapCache[targetType];
 			
 			// Create a new isntance of the targetType; and then inject the values from the source object into it
 			const target : * = instantiate(targetType, fetchConstructorArgs(source, injectionMap.getConstructorFields()));

--- a/src/org/osflash/vanilla/Vanilla.as
+++ b/src/org/osflash/vanilla/Vanilla.as
@@ -21,7 +21,7 @@ package org.osflash.vanilla
 		private static const METADATA_TYPE_KEY : String = "type";
 		
 		//Cache InjectionMap instances
-		private var injectionMapCache:Dictionary = new Dictionary;
+		private var injectionMapCache:Dictionary = new Dictionary();
 		
 		/**
 		 * Attempts to extract properties from the supplied source object into an instance of the supplied targetType.
@@ -40,18 +40,13 @@ package org.osflash.vanilla
 				return source;
 			}
 			
-			if(injectionMapCache[targetType] == undefined)
+			if (!injectionMapCache[targetType]) 
 			{
-				// Construct an InjectionMap which tells us how to inject fields from the source object into 
-				// the Target class.
-				var injectionMap : InjectionMap = new InjectionMap();
-				addReflectedRules(injectionMap, targetType, Type.forClass(targetType));
-				injectionMapCache[targetType] = injectionMap;
+			    injectionMapCache[targetType] = new InjectionMap();
+			    addReflectedRules(injectionMapCache[targetType], targetType, Type.forClass(targetType));
 			}
-			else
-			{
-				injectionMap = injectionMapCache[targetType];
-			}
+			
+			const injectionMap = injectionMapCache[targetType];
 			
 			// Create a new isntance of the targetType; and then inject the values from the source object into it
 			const target : * = instantiate(targetType, fetchConstructorArgs(source, injectionMap.getConstructorFields()));

--- a/src/org/osflash/vanilla/Vanilla.as
+++ b/src/org/osflash/vanilla/Vanilla.as
@@ -1,5 +1,6 @@
 package org.osflash.vanilla
 {
+	import flash.utils.Dictionary;
 	import org.as3commons.lang.ClassUtils;
 	import org.as3commons.lang.ObjectUtils;
 	import org.as3commons.reflect.Accessor;
@@ -19,6 +20,9 @@ package org.osflash.vanilla
 		private static const METADATA_FIELD_KEY : String = "field";
 		private static const METADATA_TYPE_KEY : String = "type";
 		
+		//Cache InjectionMap instances
+		private var injectionMapCache:Dictionary = new Dictionary;
+		
 		/**
 		 * Attempts to extract properties from the supplied source object into an instance of the supplied targetType.
 		 * 
@@ -36,10 +40,18 @@ package org.osflash.vanilla
 				return source;
 			}
 			
-			// Construct an InjectionMap which tells us how to inject fields from the source object into 
-			// the Target class.
-			const injectionMap : InjectionMap = new InjectionMap();
-			addReflectedRules(injectionMap, targetType, Type.forClass(targetType));
+			if(injectionMapCache[targetType] == undefined)
+			{
+				// Construct an InjectionMap which tells us how to inject fields from the source object into 
+				// the Target class.
+				var injectionMap : InjectionMap = new InjectionMap();
+				addReflectedRules(injectionMap, targetType, Type.forClass(targetType));
+				injectionMapCache[targetType] = injectionMap;
+			}
+			else
+			{
+				injectionMap = injectionMapCache[targetType];
+			}
 			
 			// Create a new isntance of the targetType; and then inject the values from the source object into it
 			const target : * = instantiate(targetType, fetchConstructorArgs(source, injectionMap.getConstructorFields()));

--- a/src/org/osflash/vanilla/Vanilla.as
+++ b/src/org/osflash/vanilla/Vanilla.as
@@ -21,7 +21,7 @@ package org.osflash.vanilla
 		private static const METADATA_TYPE_KEY : String = "type";
 		
 		//Cache InjectionMap instances
-		private var injectionMapCache:Dictionary = new Dictionary();
+		private var injectionMapCache : Dictionary = new Dictionary();
 		
 		/**
 		 * Attempts to extract properties from the supplied source object into an instance of the supplied targetType.
@@ -46,7 +46,7 @@ package org.osflash.vanilla
 			    addReflectedRules(injectionMapCache[targetType], targetType, Type.forClass(targetType));
 			}
 			
-			const injectionMap:InjectionMap = injectionMapCache[targetType];
+			const injectionMap : InjectionMap = injectionMapCache[targetType];
 			
 			// Create a new isntance of the targetType; and then inject the values from the source object into it
 			const target : * = instantiate(targetType, fetchConstructorArgs(source, injectionMap.getConstructorFields()));


### PR DESCRIPTION
I have to process ~10,000 JSON objects returned from a RESTful service. The original version of Vanilla.extract() method took 8.5 seconds and it reached our response limitation requirement.

By using the caching, now it takes only ~0.4 second.
